### PR TITLE
Update python_version for 3.13

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13

--- a/tufinsecuretrack.json
+++ b/tufinsecuretrack.json
@@ -15,7 +15,7 @@
     "min_phantom_version": "4.9.39220",
     "logo": "logo_tufin.svg",
     "logo_dark": "logo_tufin_dark.svg",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": true,
     "latest_tested_versions": [
         "SecureTrack version 16.2 HF2 build 77043, TufinOS Release 2.11 build 891"


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)