### PR TITLE
Fix python_version format

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format

--- a/tufinsecuretrack.json
+++ b/tufinsecuretrack.json
@@ -15,10 +15,7 @@
     "min_phantom_version": "4.9.39220",
     "logo": "logo_tufin.svg",
     "logo_dark": "logo_tufin_dark.svg",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "latest_tested_versions": [
         "SecureTrack version 16.2 HF2 build 77043, TufinOS Release 2.11 build 891"


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)